### PR TITLE
Handle case if unique_ptr is None / nullptr.

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1682,6 +1682,10 @@ struct move_only_holder_caster : type_caster_base<type> {
     }
 
     bool load(handle src, bool /*convert*/) {
+        if (src.is(none())) {
+            holder.reset();
+            return true;
+        }
         // Allow loose reference management (if it's just a plain object) or require tighter reference
         // management if it's a move container.
         object obj = extract_obj(src);

--- a/tests/test_smart_ptr.py
+++ b/tests/test_smart_ptr.py
@@ -236,6 +236,9 @@ def test_unique_ptr_arg():
     m.unique_ptr_terminal(m.UniquePtrHeld(2))
     assert stats.alive() == 0
 
+    assert m.unique_ptr_pass_through(None) is None
+    m.unique_ptr_terminal(None)
+
 
 def test_unique_ptr_to_shared_ptr():
     obj = m.shared_ptr_held_in_unique_ptr()


### PR DESCRIPTION
Ran into this bug when testing out C++ template binding stuff.
Relatively simple fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/pybind11/4)
<!-- Reviewable:end -->
