### PR TITLE
wrapper: Robustify check, don't require that alias classes inherit, allow alias to be wrapped directly.

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1013,12 +1013,25 @@ auto method_adaptor(Return (Class::*pmf)(Args...) const) -> Return (Derived::*)(
     return pmf;
 }
 
+namespace detail {
 
+template <template <typename...> class Tpl>
+struct is_base_template_of_impl {
+    // Use pointers for robustness.
+    template <typename ... Base>
+    static std::true_type check(const Tpl<Base...>*);
+    static std::false_type check(void*);
+};
 
-template <typename type, bool compatible>
+template <template <typename...> class Tpl, typename Derived>
+using is_base_template_of =
+    decltype(is_base_template_of_impl<Tpl>::check(
+        std::declval<Derived*>()));
+
+template <typename type, typename alias, bool compatible>
 struct wrapper_interface_impl {
     static void use_cpp_lifetime(type* cppobj, object&& obj, detail::HolderTypeId holder_type_id) {
-        auto* tr = dynamic_cast<wrapper<type>*>(cppobj);
+        auto* tr = dynamic_cast<alias*>(cppobj);
         if (tr == nullptr) {
             // This has been invoked at too high of a level; should use a
             // downcast class's `release_to_cpp` mechanism (if it supports it).
@@ -1033,7 +1046,7 @@ struct wrapper_interface_impl {
     }
 
     static object release_cpp_lifetime(type* cppobj) {
-        auto* tr = dynamic_cast<wrapper<type>*>(cppobj);
+        auto* tr = dynamic_cast<alias*>(cppobj);
         if (tr == nullptr) {
             // This shouldn't happen here...
             throw std::runtime_error("Internal error?");
@@ -1041,13 +1054,10 @@ struct wrapper_interface_impl {
         // Return newly created object.
         return tr->release_cpp_lifetime();
     }
-    static wrapper<type>* run(type*, std::false_type) {
-        return nullptr;
-    }
 };
 
-template <typename type>
-struct wrapper_interface_impl<type, false> {
+template <typename type, typename alias>
+struct wrapper_interface_impl<type, alias, false> {
     static void use_cpp_lifetime(type*, object&&, detail::HolderTypeId) {
         // This should be captured by runtime flag.
         // TODO(eric.cousineau): Runtime flag may not be necessary.
@@ -1156,6 +1166,8 @@ struct holder_check_impl<detail::HolderTypeId::UniquePtr> : public holder_check_
       }
 };
 
+}  // namespace detail
+
 template <typename type_, typename... options>
 class class_ : public detail::generic_type {
     template <typename T> using is_holder = detail::is_holder_type<type_, T>;
@@ -1169,7 +1181,8 @@ public:
     using type = type_;
     using type_alias = detail::exactly_one_t<is_subtype, void, options...>;
     constexpr static bool has_alias = !std::is_void<type_alias>::value;
-    constexpr static bool has_wrapper = std::is_base_of<wrapper<type>, type_alias>::value;
+    constexpr static bool has_wrapper =
+        detail::is_base_template_of<wrapper, type_alias>::value;
     using holder_type = detail::exactly_one_t<is_holder, std::unique_ptr<type>, options...>;
     constexpr static detail::HolderTypeId holder_type_id = detail::get_holder_type_id<holder_type>::value;
 
@@ -1230,8 +1243,8 @@ public:
         return detail::get_type_info(id);
     }
 
-    typedef wrapper_interface_impl<type, has_wrapper> wrapper_interface;
-    using holder_check = holder_check_impl<holder_type_id>;
+    using wrapper_interface = detail::wrapper_interface_impl<type, type_alias, has_wrapper>;
+    using holder_check = detail::holder_check_impl<holder_type_id>;
 
     static bool allow_destruct(detail::instance* inst, detail::holder_erased holder) {
         // TODO(eric.cousineau): There should not be a case where shared_ptr<> lives in

--- a/tests/test_ownership_transfer.py
+++ b/tests/test_ownership_transfer.py
@@ -10,8 +10,8 @@ def define_child(name, base_type, stats_type):
     # `stats_type` is meant to enable us to use `ConstructorStats` exclusively for a Python class.
 
     class ChildT(base_type):
-        def __init__(self, value):
-            base_type.__init__(self, value)
+        def __init__(self, *args):
+            base_type.__init__(self, *args)
             self.icstats = m.get_instance_cstats(ChildT.get_cstats(), self)
             self.icstats.track_created()
 
@@ -77,7 +77,7 @@ def test_shared_ptr_derived_slicing(capture):
     del obj
     assert cstats.alive() == 0
     # Use something more permanent.
-    obj = Child(10)
+    obj = Child()  # Use factory method.
     obj_weak = weakref.ref(obj)
     assert cstats.alive() == 1
     c = m.BaseContainer(obj)
@@ -137,8 +137,9 @@ def test_unique_ptr_derived_slicing(capture):
     del obj
     assert cstats.alive() == 0
 
-    # Ensure that we can pass between Python -> C++ -> Python.
-    obj = m.BaseUniqueContainer(ChildUnique(10)).release()
+    # Ensure that we can pass between Python -> C++ -> Python
+    # (using factory method).
+    obj = m.BaseUniqueContainer(ChildUnique()).release()
     obj = m.BaseUniqueContainer(obj).release()
     assert obj.value() == 100
     del obj


### PR DESCRIPTION
This allows a class to be declared using `py::class_<Class, py::wrapper<Alias>>`, in addition to having `Alias` extend `py::wrapper<Class>`.

My original intent was to hide the details of `py::wrapper` entirely; however, this breaks backwards compatibility with factory alias methods, such as [this one](https://github.com/pybind/pybind11/blob/add56ccdcac23a6c522a2c1174a866e293c61dab/tests/test_factory_constructors.cpp#L215), since we'd have to ensure that the wrapped alias type is constructed.

This also minimizes some of the cruft doxygen comments for `py::wrapper`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/pybind11/8)
<!-- Reviewable:end -->
