### PR TITLE
eigen: Disable dtype=object arrays from being referenced

### DIFF
--- a/include/pybind11/numpy.h
+++ b/include/pybind11/numpy.h
@@ -1229,19 +1229,22 @@ private:
         (::std::vector<::pybind11::detail::field_descriptor> \
          {PYBIND11_MAP2_LIST (PYBIND11_FIELD_DESCRIPTOR_EX, Type, __VA_ARGS__)})
 
+struct npy_format_descriptor_object {
+public:
+    enum { value = npy_api::NPY_OBJECT_ };
+    static pybind11::dtype dtype() {
+        if (auto ptr = npy_api::get().PyArray_DescrFromType_(value)) {
+            return reinterpret_borrow<pybind11::dtype>(ptr);
+        }
+        pybind11_fail("Unsupported buffer format!");
+    }
+    static constexpr auto name = _("object");
+};
+
 #define PYBIND11_NUMPY_OBJECT_DTYPE(Type) \
     namespace pybind11 { namespace detail { \
-        template <> struct npy_format_descriptor<Type> { \
-        public: \
-            enum { value = npy_api::NPY_OBJECT_ }; \
-            static pybind11::dtype dtype() { \
-                if (auto ptr = npy_api::get().PyArray_DescrFromType_(value)) { \
-                    return reinterpret_borrow<pybind11::dtype>(ptr); \
-                } \
-                pybind11_fail("Unsupported buffer format!"); \
-            } \
-            static constexpr auto name = _("object"); \
-        }; \
+        template <> struct npy_format_descriptor<Type> : \
+            public npy_format_descriptor_object {}; \
     }}
 
 #endif // __CLION_IDE__


### PR DESCRIPTION
In preparation for scalar type conversion with `dtype=object`, we should ensure that copies should be made when able, but we should error out as early as possible if a user attempts tries to reference existing memory when using `dtype=object`.

This can help point out areas that can be helped by a custom user-defined dtype, or something that should be reworked in it's generic form.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/pybind11/17)
<!-- Reviewable:end -->
