### PR TITLE
cast: Ensure that pointers do not use rvalue / move overload

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -1970,7 +1970,7 @@ detail::enable_if_t<
 
 template <typename T>
 detail::enable_if_t<
-        std::is_rvalue_reference<T&&>::value && !detail::is_pyobject<detail::intrinsic_t<T>>::value, object>
+        std::is_rvalue_reference<T&&>::value && !std::is_pointer<T>::value && !detail::is_pyobject<detail::intrinsic_t<T>>::value, object>
     cast(T&& value) {
     // Have to use `pybind11::move` because some compilers might try to bind `move` to `std::move`...
     return pybind11::move<T>(std::move(value));

--- a/tests/test_builtin_casters.cpp
+++ b/tests/test_builtin_casters.cpp
@@ -167,4 +167,13 @@ TEST_SUBMODULE(builtin_casters, m) {
         py::object o = py::cast(v);
         return py::cast<void *>(o) == v;
     });
+
+    // For Drake issue: https://github.com/RobotLocomotion/drake/issues/9398
+    m.def("test_pointer_caster", []() -> bool {
+        UserType a;
+        UserType *a_ptr = &a;
+        py::object o = py::cast(&a); // Rvalue
+        py::object o1 = py::cast(a_ptr); // Non-rvalue
+        return (py::cast<UserType*>(o) == a_ptr && py::cast<UserType*>(o1) == a_ptr);
+    });
 }

--- a/tests/test_builtin_casters.py
+++ b/tests/test_builtin_casters.py
@@ -340,3 +340,7 @@ def test_int_long():
 
 def test_void_caster_2():
     assert m.test_void_caster()
+
+
+def test_pointer_caster():
+    assert m.test_pointer_caster()


### PR DESCRIPTION
[Towards Issue 9398](https://github.com/RobotLocomotion/drake/issues/9398)

Requires:
- [x] #29 (CI fixes)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/pybind11/28)
<!-- Reviewable:end -->
