### PR TITLE
Obey __cpp_sized_deallocation and __cpp_aligned_new

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -701,10 +701,10 @@ public:
             if (type->operator_new) {
                 vptr = type->operator_new(type->type_size);
             } else {
-                #if defined(PYBIND11_CPP17)
+                #ifdef __cpp_aligned_new
                     if (type->type_align > __STDCPP_DEFAULT_NEW_ALIGNMENT__)
                         vptr = ::operator new(type->type_size,
-                                              (std::align_val_t) type->type_align);
+                                              std::align_val_t(type->type_align));
                     else
                 #endif
                 vptr = ::operator new(type->type_size);

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1000,14 +1000,21 @@ void call_operator_delete(T *p, size_t s, size_t) { T::operator delete(p, s); }
 
 inline void call_operator_delete(void *p, size_t s, size_t a) {
     (void)s; (void)a;
-#if defined(PYBIND11_CPP17)
-    if (a > __STDCPP_DEFAULT_NEW_ALIGNMENT__)
-        ::operator delete(p, s, std::align_val_t(a));
-    else
+    #ifdef __cpp_aligned_new
+        if (a > __STDCPP_DEFAULT_NEW_ALIGNMENT__) {
+            #ifdef __cpp_sized_deallocation
+                ::operator delete(p, s, std::align_val_t(a));
+            #else
+                ::operator delete(p, std::align_val_t(a));
+            #endif
+            return;
+        }
+    #endif
+    #ifdef __cpp_sized_deallocation
         ::operator delete(p, s);
-#else
-    ::operator delete(p);
-#endif
+    #else
+        ::operator delete(p);
+    #endif
 }
 
 NAMESPACE_END(detail)


### PR DESCRIPTION
Don't assume that just because the language version is C++17 that the standard library offers all C++17 features, too.  When using clang-6.0 and --std=c++17 on Ubuntu 18.04 with libstdc++, __cpp_sized_deallocation is false.

CI testing is via RobotLocomotion/drake#11650.

Probably the same as pybind/pybind11#1604.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/pybind11/30)
<!-- Reviewable:end -->
