### PR TITLE
class_: Register `reclaim_from_cpp` with constructing type

### DIFF
--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1392,11 +1392,17 @@ public:
         auto* tinfo = get_type_info();
         // TODO(eric.cousineau): Should relax this to not require a holder be constructed,
         // only that the holder itself be default (unique_ptr<>).
-        if (inst->owned || v_h.holder_constructed()) {
-            throw std::runtime_error("Derived Python object should live in C++");
+        if (inst->owned) {
+            throw std::runtime_error(
+                "reclaim_from_cpp: Python object already owned! Did you forget to explicitly use a "
+                "py::return_value_policy (e.g. reference or reference internal) when passing back "
+                "non-owned pointers of the C++ object?");
+        }
+        if (v_h.holder_constructed()) {
+            throw std::runtime_error("reclaim_from_cpp: Holder already exists - internal error?");
         }
         if (!external_holder_raw) {
-            throw std::runtime_error("Internal error - not external holder?");
+            throw std::runtime_error("reclaim_from_cpp: No external holder - internal error?");
         }
         // Is this valid?
         handle h(reinterpret_cast<PyObject*>(inst));
@@ -1425,7 +1431,7 @@ public:
                 break;
             }
             default: {
-                throw std::runtime_error("Unsupported load type");
+                throw std::runtime_error("reclaim_from_cpp: Unsupported load type");
             }
         }
         inst->owned = true;
@@ -1715,6 +1721,9 @@ private:
         // Is there a way to check if `__del__` is an instance-assigned
         // method? (Rather than a class method?)
         object del_orig = getattr(h_type, "__del__", none());
+
+        // Set reclaim method.
+        inst->reclaim_from_cpp = reclaim_from_cpp;
 
 #if defined(PYPY_VERSION)
         // PyPy will not execute an arbitrarily-added `__del__` method.

--- a/tests/test_smart_ptr.py
+++ b/tests/test_smart_ptr.py
@@ -335,3 +335,17 @@ def test_unique_ptr_overload_fail():
     out = m.unique_ptr_overload(obj, m.SecondT())
     assert out["obj"] is obj
     assert out["overload"] == 2
+
+
+def test_unique_ptr_held_container_from_cpp():
+
+    def check_reset(obj_new):
+        c = m.UniquePtrHeldContainer()
+        obj = c.get()
+        assert obj is not None
+        obj_ref = c.reset(obj_new)
+        assert obj is obj_ref
+        assert c.get() is obj_new
+
+    check_reset(obj_new=m.UniquePtrHeld(10))
+    check_reset(obj_new=None)


### PR DESCRIPTION
Towards https://github.com/RobotLocomotion/drake/issues/13056

- [x] Test in downstream: https://github.com/robotlocomotion/drake/pull/13044

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/pybind11/33)
<!-- Reviewable:end -->
