### PR TITLE
eigen: Don't require conformability on length-0 dimensions

### DIFF
--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -100,9 +100,9 @@ template <bool EigenRowMajor> struct EigenConformable {
         return
             !negativestrides &&
             (props::inner_stride == Eigen::Dynamic || props::inner_stride == stride.inner() ||
-                (EigenRowMajor ? cols : rows) == 1) &&
+                (EigenRowMajor ? cols : rows) <= 1) &&
             (props::outer_stride == Eigen::Dynamic || props::outer_stride == stride.outer() ||
-                (EigenRowMajor ? rows : cols) == 1);
+                (EigenRowMajor ? rows : cols) <= 1);
     }
     operator bool() const { return conformable; }
 };

--- a/tests/test_eigen.cpp
+++ b/tests/test_eigen.cpp
@@ -359,10 +359,12 @@ TEST_SUBMODULE(eigen, m) {
     m.def("get_elem_rm_nocopy", [](Eigen::Ref<const Eigen::Matrix<long, -1, -1, Eigen::RowMajor>> &m) -> long { return m(2, 1); },
             py::arg().noconvert());
 
-    // test_issue738
+    // test_issue738_issue2038
     // Issue #738: 1xN or Nx1 2D matrices were neither accepted nor properly copied with an
     // incompatible stride value on the length-1 dimension--but that should be allowed (without
     // requiring a copy!) because the stride value can be safely ignored on a size-1 dimension.
+    // Issue #2039: 0xN (col-major) or Nx0 (row-major) matrices were not accepted properly, due to a similar
+    // situation.
     m.def("iss738_f1", &adjust_matrix<const Eigen::Ref<const Eigen::MatrixXd> &>, py::arg().noconvert());
     m.def("iss738_f2", &adjust_matrix<const Eigen::Ref<const Eigen::Matrix<double, -1, -1, Eigen::RowMajor>> &>, py::arg().noconvert());
 

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -753,13 +753,17 @@ def test_sparse_signature(doc):
     """  # noqa: E501 line too long
 
 
-def test_issue738():
-    """Ignore strides on a length-1 dimension (even if they would be incompatible length > 1)"""
+def test_issue738_issue2038():
+    """Ignore strides on a length-0 or -1 dimension (even if they would be incompatible
+    length > 1)"""
     assert np.all(m.iss738_f1(np.array([[1., 2, 3]])) == np.array([[1., 102, 203]]))
     assert np.all(m.iss738_f1(np.array([[1.], [2], [3]])) == np.array([[1.], [12], [23]]))
 
     assert np.all(m.iss738_f2(np.array([[1., 2, 3]])) == np.array([[1., 102, 203]]))
     assert np.all(m.iss738_f2(np.array([[1.], [2], [3]])) == np.array([[1.], [12], [23]]))
+
+    assert np.all(m.iss738_f1(np.zeros((0, 2))) == np.zeros((0, 2)))
+    assert np.all(m.iss738_f2(np.zeros((2, 0))) == np.zeros((2, 0)))
 
 
 def test_issue1105():


### PR DESCRIPTION
This is a patch that proactively incorporates the following upstream PR (not sure how long it will take to review):
https://github.com/pybind/pybind11/pull/2099

Towards https://github.com/RobotLocomotion/drake/issues/12633

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/pybind11/38)
<!-- Reviewable:end -->
