### PR TITLE
pytypes: Resurrect via leak instead of un-finalize in Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,14 @@ matrix:
     # - $PY_CMD -m sphinx -W -b html docs docs/.build
     - |
       # Make sure setup.py distributes and installs all the headers
+      set -ex
       $PY_CMD setup.py sdist
       $PY_CMD -m pip install --user -U ./dist/*
       installed=$($PY_CMD -c "import pybind11; print(pybind11.get_include(True) + '/pybind11')")
       diff -rq $installed ./include/pybind11
     - |
       # Barebones build
+      set -ex
       cmake -DCMAKE_BUILD_TYPE=Debug -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON -DPYTHON_EXECUTABLE=$(which $PY_CMD) .
       make pytest -j 2 && make cpptest -j 2
   # The following are regular test configurations, including optional dependencies.
@@ -130,6 +132,7 @@ matrix:
       - $PY_CMD -m pip install --user --upgrade pytest
     script:
       - |
+        set -ex
         # Barebones build
         cmake -DCMAKE_BUILD_TYPE=Debug -DPYBIND11_WERROR=ON -DDOWNLOAD_CATCH=ON -DPYTHON_EXECUTABLE=$(which $PY_CMD) .
         make pytest -j 2 && make cpptest -j 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -126,7 +126,8 @@ matrix:
     # TODO: remove next before_install, install and script clause when the wheels become available
     before_install:
       - pyenv global $(pyenv whence 2to3)  # activate all python versions
-      - PY_CMD=python3
+      - PY_CMD=python3.8
+      - $PY_CMD -m ensurepip --user
       - $PY_CMD -m pip install --user --upgrade pip wheel setuptools
     install:
       - $PY_CMD -m pip install --user --upgrade pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -141,17 +141,18 @@ matrix:
     name: Python 3.7, c++14, AppleClang 9, Debug build
     osx_image: xcode9.4
     env: PYTHON=3.7 CPP=14 CLANG DEBUG=1
-  # Test a PyPy 2.7 build
-  - os: linux
-    dist: trusty
-    env: PYPY=5.8 PYTHON=2.7 CPP=11 GCC=4.8
-    name: PyPy 5.8, Python 2.7, c++11, gcc 4.8
-    addons:
-      apt:
-        packages:
-          - libblas-dev
-          - liblapack-dev
-          - gfortran
+  # WARNING: This current fails on download. Should try to upgrade OS + Python version?
+  # # Test a PyPy 2.7 build
+  # - os: linux
+  #   dist: trusty
+  #   env: PYPY=5.8 PYTHON=2.7 CPP=11 GCC=4.8
+  #   name: PyPy 5.8, Python 2.7, c++11, gcc 4.8
+  #   addons:
+  #     apt:
+  #       packages:
+  #         - libblas-dev
+  #         - liblapack-dev
+  #         - gfortran
   # Build in 32-bit mode and tests against the CMake-installed version
   - os: linux
     dist: trusty

--- a/README.md
+++ b/README.md
@@ -8,13 +8,21 @@ This is a fork of the [official `pybind/pybind11` repository](https://github.com
 All the links and badges within this document may link back to the official
 repository.
 
+This fork's CI badge:
+
+[![Build Status](https://travis-ci.com/RobotLocomotion/pybind11.svg?branch=drake)](https://travis-ci.com/github/RobotLocomotion/pybind11)
+
 # pybind11 — Seamless operability between C++11 and Python
+
+<!--
+Drake Fork: Hide upstream CI badges.
 
 [![Documentation Status](https://readthedocs.org/projects/pybind11/badge/?version=master)](http://pybind11.readthedocs.org/en/master/?badge=master)
 [![Documentation Status](https://readthedocs.org/projects/pybind11/badge/?version=stable)](http://pybind11.readthedocs.org/en/stable/?badge=stable)
 [![Gitter chat](https://img.shields.io/gitter/room/gitterHQ/gitter.svg)](https://gitter.im/pybind/Lobby)
 [![Build Status](https://travis-ci.org/pybind/pybind11.svg?branch=master)](https://travis-ci.org/pybind/pybind11)
 [![Build status](https://ci.appveyor.com/api/projects/status/riaj54pn4h08xy40?svg=true)](https://ci.appveyor.com/project/wjakob/pybind11)
+-->
 
 **pybind11** is a lightweight header-only library that exposes C++ types in Python
 and vice versa, mainly to create Python bindings of existing C++ code. Its

--- a/README_DRAKE.md
+++ b/README_DRAKE.md
@@ -43,19 +43,27 @@ source code (e.g. no whitespace reflowing), and try to stay relatively close to
 For simplicity, these checks are copied from upstream's CI which uses Travis
 CI as part of GitHub's Checks. They test:
 
-* Ubuntu and macOS
+* Ubuntu and macOS (Windows tests disabled)
 * C++11, C++14, and C++17
 * Release and debug builds
 * GCC 4.8, 6, and 7
 * clang 7
 * Apple clang 7.3 and 9
 * 64bit and 32bit
-* CPython and PyPy
-* Python 2.7, 3.5, 3.6, and 3.7
+* CPython and PyPy (though PyPy is partially supported on this fork)
+* Python 2.7, 3.5, 3.6, 3.7, and 3.8
 
 To see builds, see [this fork's Travis CI page](https://travis-ci.com/RobotLocomotion/pybind11/branches).
 
 Windows testing (with AppVeyor) is disabled for this repository.
+
+### Quick Testing
+
+    mkdir build && cd build
+    cmake .. \
+        -DPYTHON_EXECUTABLE=$(which python3) \
+        -DPYBIND11_TEST_OVERRIDE='test_builtin_casters.cpp;test_class.cpp;test_eigen.cpp;test_multiple_inheritance.cpp;test_ownership_transfer.cpp;test_smart_ptr.cpp'
+    make -j 4 pytest
 
 ## Local Git Setup
 


### PR DESCRIPTION
See: https://github.com/RobotLocomotion/drake/issues/13026

Relates to the Drake 3.7 -> 3.8 transition from RobotLocomotion/drake#13097.

Requires:
- [x] #40 CI updates to actually run Python 3.8 (folded in here to leverage 3.8 actually working)
- [x] Drake testing (local for 3.8, and basic CI) to ensure this doesn't get too funky

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/pybind11/39)
<!-- Reviewable:end -->
