### PR TITLE
drake: Workaround "Assertion '!PyErr_Occurred()'" for dtype=object

### DIFF
--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -157,6 +157,12 @@ extern "C" inline int pybind11_meta_setattro(PyObject* obj, PyObject* name, PyOb
  * to do a special case bypass for PyInstanceMethod_Types.
  */
 extern "C" inline PyObject *pybind11_meta_getattro(PyObject *obj, PyObject *name) {
+    // Workaround! See:
+    // https://github.com/RobotLocomotion/drake/issues/14740
+    // https://github.com/pybind/pybind11/pull/2685
+    if (PyErr_Occurred()) {
+        PyErr_Clear();
+    }
     PyObject *descr = _PyType_Lookup((PyTypeObject *) obj, name);
     if (descr && PyInstanceMethod_Check(descr)) {
         Py_INCREF(descr);


### PR DESCRIPTION
Resolves https://github.com/RobotLocomotion/drake/issues/14740

Mimics solution from https://github.com/pybind/pybind11/pull/2685 based on this stacktrace:
https://gist.github.com/EricCousineau-TRI/a60c2ba37eb7db04c183f5be81a267b0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/pybind11/52)
<!-- Reviewable:end -->
