### PR TITLE
Fix arrays with zero-size dimensions

### DIFF
--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -840,6 +840,8 @@ def test_issue738_issue2038():
     )
 
     assert np.all(m.iss738_f1(np.zeros((0, 2))) == np.zeros((0, 2)))
+    assert np.all(m.iss738_f1(np.zeros((2, 0))) == np.zeros((2, 0)))
+    assert np.all(m.iss738_f2(np.zeros((0, 2))) == np.zeros((0, 2)))
     assert np.all(m.iss738_f2(np.zeros((2, 0))) == np.zeros((2, 0)))
 
 


### PR DESCRIPTION
When converting an array to an Eigen matrix, ignore the strides if any dimension size is 0. If the array is empty, the strides aren't relevant, and especially numpy ≥ 1.23 explicitly sets the strides to 0 in this case. (See numpy/numpy@dd5ab7b11520.)

Update tests to verify that this works, and continues to work. (The updated test would have caught the behavior change with numpy 1.23.) This expands on the tests added by #38, but also reverts the logic change from that PR, as it is no longer needed, and brings the code closer in line with upstream, since #38 was never pushed upstream.

+@EricCousineau-TRI for review, please.

See also https://github.com/pybind/pybind11/pull/4038.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/pybind11/58)
<!-- Reviewable:end -->
