### PR TITLE
Skip Eigen::Sparse overloads when scipy is not available

### DIFF
--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -730,7 +730,14 @@ struct type_caster<Type, enable_if_t<is_eigen_sparse<Type>::value>> {
             return false;
 
         auto obj = reinterpret_borrow<object>(src);
-        object sparse_module = module_::import("scipy.sparse");
+        object sparse_module;
+        try {
+            sparse_module = module_::import("scipy.sparse");
+        } catch (const error_already_set &) {
+            // As a Drake-specific amendment, we skip Eigen::Sparse overloads
+            // when scipy is not available, instead of raising an import error.
+            return false;
+        }
         object matrix_type = sparse_module.attr(
             rowMajor ? "csr_matrix" : "csc_matrix");
 


### PR DESCRIPTION
For https://github.com/RobotLocomotion/drake/pull/17570.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/pybind11/59)
<!-- Reviewable:end -->
