### PR TITLE
Give ability to bind `SparseVector`

### DIFF
--- a/include/pybind11/eigen/matrix.h
+++ b/include/pybind11/eigen/matrix.h
@@ -880,7 +880,11 @@ struct type_caster<Type, enable_if_t<is_eigen_sparse<Type>::value>> {
     }
 
     static handle cast(const Type &src, return_value_policy /* policy */, handle /* parent */) {
-        const_cast<Type &>(src).makeCompressed();
+        if constexpr (!std::is_same_v<Type, Eigen::SparseVector) {
+            const_cast<Type &>(src).makeCompressed();
+        // use type specific operations... 
+        } 
+        
 
         object matrix_type
             = module_::import("scipy.sparse").attr(rowMajor ? "csr_matrix" : "csc_matrix");


### PR DESCRIPTION
I noticed that currently it is not possible to bind Drake methods which output a `SparseVector` because "there is no notion of compressed/uncompressed mode for a [SparseVector](https://eigen.tuxfamily.org/dox/classEigen_1_1SparseVector.html)". 

This is a small fix attempting to fix this, but I am not familiar with this repository so don't know how to test this nor upgrade Drake with the fix.

cc @EricCousineau-TRI since you seem to be the maintainer

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/pybind11/70)
<!-- Reviewable:end -->
