### PR TITLE
Replace removed itemset method

### DIFF
--- a/include/pybind11/eigen/matrix.h
+++ b/include/pybind11/eigen/matrix.h
@@ -283,6 +283,8 @@ eigen_array_cast(typename props::Type const &src, handle base = handle(), bool w
                       {(size_t) src.size()},
                       nullptr,
                       empty_base);
+            auto _m_arr = a.mutable_unchecked<object, 1>();
+
             constexpr bool is_row = props::fixed_rows && props::rows == 1;
             for (ssize_t i = 0; i < src.size(); ++i) {
                 const Scalar src_val = is_row ? src(0, i) : src(i, 0);
@@ -291,13 +293,16 @@ eigen_array_cast(typename props::Type const &src, handle base = handle(), bool w
                 if (!value_) {
                     return handle();
                 }
-                a.attr("itemset")(i, value_);
+
+                _m_arr[i] = value_;
             }
         } else {
             a = array(npy_format_descriptor<Scalar>::dtype(),
                       {(size_t) src.rows(), (size_t) src.cols()},
                       nullptr,
                       empty_base);
+            auto _m_arr = a.mutable_unchecked<object, 2>();
+
             for (ssize_t i = 0; i < src.rows(); ++i) {
                 for (ssize_t j = 0; j < src.cols(); ++j) {
                     auto value_ = reinterpret_steal<object>(
@@ -305,7 +310,8 @@ eigen_array_cast(typename props::Type const &src, handle base = handle(), bool w
                     if (!value_) {
                         return handle();
                     }
-                    a.attr("itemset")(i, j, value_);
+
+                    _m_arr(i,j) = value_;
                 }
             }
         }


### PR DESCRIPTION
Numpy 2.0 removes the itemset Python method from
the API
Switch to setting array values via direct array
interface for pybind11::object types

Mutable array access is unchecked for dimension
boundaries

> Note: I tested this locally against Drake's bindings test suite, there were a few errors that seemed unrelated, so this approach may not be complete if those errors turn out to be related.

> Note: I will be out for the upcoming holiday and the following day, so if edits are required prior to my return, please ping both myself and @BetsyMcPhail (thanks Betsy for offering to take this for a couple days)

Fixes https://github.com/RobotLocomotion/drake/issues/21577
<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/pybind11/72)
<!-- Reviewable:end -->
